### PR TITLE
NO-JIRA: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/sonarlint-team
+.github/CODEOWNERS @sonarsource/devex-ide-squad


### PR DESCRIPTION
This will be cherry-picked for both the branches for 1.39.6 / 1.39.10 we maintain.