### PR TITLE
Add SCA exclusions

### DIFF
--- a/.github/workflows/build_scan_dotnet.sh
+++ b/.github/workflows/build_scan_dotnet.sh
@@ -33,6 +33,7 @@ SONAR_PARAMS=(
   -d:sonar.analysis.pipeline="$GITHUB_RUN_ID"
   -d:sonar.analysis.sha1="${GITHUB_SHA}"
   -d:sonar.scanner.scanAll=false
+  -d:sonar.sca.exclusions="test-assets/**"
 )
 
 if [ "$GITHUB_BRANCH" == "master" ] && [ "$PULL_REQUEST" == "false" ]; then


### PR DESCRIPTION
The Next squad reached out to the SCA squad to let us know about an error they're seeing in the Next logs regarding this repo.

The SonarQube scans are failing due to some of the test fixtures. But you typically don't want to scan test fixtures anyway, since they aren't being executed. This PR excludes them, so that your scans will (hopefully) start showing dependencies.